### PR TITLE
Flexible Grid row height

### DIFF
--- a/src/control/grid/internal/GridRow.tsx
+++ b/src/control/grid/internal/GridRow.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import styled from "../../../styled-components";
 
 const GRID_CELL_PADDING_X = 32;
+const GRID_CELL_PADDING_Y = 8;
 
 interface ISpacerProps {
     odd?: boolean;
@@ -16,7 +17,7 @@ interface IItemProps {
     className?: string;
 }
 const Item = styled<IItemProps, "div">("div")`
-    padding: 10px ${GRID_CELL_PADDING_X}px;
+    padding: ${GRID_CELL_PADDING_Y}px ${GRID_CELL_PADDING_X}px;
     background-color: ${({ odd, theme }) => odd ? theme.colors.gridOddRowBg : theme.colors.gridEvenRowBg};
 `;
 const VertBorder = styled.div`

--- a/src/control/grid/internal/GridRow.tsx
+++ b/src/control/grid/internal/GridRow.tsx
@@ -8,7 +8,6 @@ interface ISpacerProps {
     className?: string;
 }
 const Spacer = styled<ISpacerProps, "div">("div")`
-    height: 32px;
     background-color: ${({ odd, theme }) => odd ? theme.colors.gridOddRowBg : theme.colors.gridEvenRowBg};
 `;
 
@@ -17,8 +16,7 @@ interface IItemProps {
     className?: string;
 }
 const Item = styled<IItemProps, "div">("div")`
-    height: 32px;
-    padding: 0 ${GRID_CELL_PADDING_X}px;
+    padding: 10px ${GRID_CELL_PADDING_X}px;
     background-color: ${({ odd, theme }) => odd ? theme.colors.gridOddRowBg : theme.colors.gridEvenRowBg};
 `;
 const VertBorder = styled.div`

--- a/src/control/grid/internal/header/GridHeader.tsx
+++ b/src/control/grid/internal/header/GridHeader.tsx
@@ -14,7 +14,6 @@ interface IGridHeaderProps {
 }
 
 const HeaderSpacer = styled.div`
-    height: 32px;
     border-bottom: 1px solid ${props => props.theme.colors.gridBorder};
     background-color: ${props => props.theme.colors.gridEvenRowBg};
     display: flex;

--- a/src/control/grid/internal/header/GridHeaderItem.tsx
+++ b/src/control/grid/internal/header/GridHeaderItem.tsx
@@ -15,9 +15,7 @@ interface IHeaderItemProps {
 }
 const HeaderItem = styled<IHeaderItemProps, "div">("div")`
     background: ${props => props.theme.colors.gridEvenRowBg};
-    height: 32px;
-    padding: 0 8px 0 32px;
-    /* padding-right: 36px; */
+    padding: 10px 8px 10px 32px;
     border-bottom: 1px solid ${props => props.theme.colors.gridBorder};
     cursor: ${props => props.isSortable ? "pointer" : "default"};
     display: flex;


### PR DESCRIPTION
Removed the fixed row height (both header and content rows) from the grid component, enabling the grid rows to expand (i.e. if a cell contains multiple lines of text). Instead, the correct row height / spacing is achieved by setting a vertical padding.

With the padding values selected in this PR, the visual appearance of the grids used in the BE should stay the same (tested on account tx grid with Chrome Dev Tools).